### PR TITLE
Jschoudt remove proxy

### DIFF
--- a/module.json
+++ b/module.json
@@ -5,7 +5,7 @@
   "version": "2.2.8",
   "minimumCoreVersion": "0.7.5",
   "compatibleCoreVersion": "0.7.9",
-  "author": "Sebastian Will (vttassets@gmail.com), MrPrimate (jack@mrprimate.co.uk",
+  "author": "Sebastian Will (vttassets@gmail.com), MrPrimate (jack@mrprimate.co.uk)",
   "languages": [
     {
       "lang": "en",

--- a/src/utils.js
+++ b/src/utils.js
@@ -65,8 +65,7 @@ export default class Utils {
       img.addEventListener("error", event => {
         reject(event);
       });
-      let imgSrc = url.toLowerCase().indexOf("http") === 0 ? "https://proxy.iungimus.de/get/" + url : url;
-      img.src = imgSrc;
+      img.src = url;
     });
   }
 


### PR DESCRIPTION
The proxy https://proxy.iungimus.de/get/ was failing for me. I couldn't find where in the version history for this file that this was added. I suspect it was added in [1.0.11](https://github.com/jschoudt/vtta-tokenizer/blob/jschoudt-remove-proxy/changelog.md#1011---2019-21-11) to improve performance. There was a warning there as well:
>Switched to my own CORS proxy to speed up loading times. Whoever may be tempted: Please do not abuse the server, or I will need to take it offline - thank you for your understanding

I suspect that either I've been blocked or the original author's proxy has been shut down.

Removing this proxy and running the module from my fork seemed to resolve my issues. I'm not sure what other issues might arise.